### PR TITLE
Fixing enums - using final Strings instead

### DIFF
--- a/Java/src/main/java/com/gildedrose/Constants.java
+++ b/Java/src/main/java/com/gildedrose/Constants.java
@@ -1,18 +1,8 @@
 package com.gildedrose;
 
-public enum Constants {
-    BRIE("Aged Brie"),
-    PASS("Backstage passes to a TAFKAL80ETC concert"),
-    SULFURAS("Sulfuras, Hand of Ragnaros"),
-    CONJURED("Conjured");
-    
-    private String name;
-    
-    Constants(String n) {
-        name = n;
-    }
-    
-    public String getName() {
-        return name;
-    }
+public interface Constants {
+	public static final String BRIE = "Aged Brie";
+	public static final String PASS = "Backstage passes to a TAFKAL80ETC concert";
+	public static final String SULFURAS = "Sulfuras, Hand of Ragnaros";
+	public static final String CONJURED = "Conjured";
 }

--- a/Java/src/main/java/com/gildedrose/GildedRose.java
+++ b/Java/src/main/java/com/gildedrose/GildedRose.java
@@ -14,7 +14,7 @@ class GildedRose {
         if (validItems()) {
             for (Item item : items) {
                 switch(item.name) {
-                case "Aged Brie":
+                case Constants.BRIE:
                     if (item.sellIn >= 0) {
                     	//before sellIn, quality increases with age, never goes beyond 50
                     	item.quality++;
@@ -26,7 +26,7 @@ class GildedRose {
                     }
                     item.sellIn--;
                     break;
-                case "Backstage passes to a TAFKAL80ETC concert":
+                case Constants.PASS:
                     if (item.sellIn <= 0) {
                 		//quality drops to 0 after the concert
                 		item.quality = 0;
@@ -41,10 +41,10 @@ class GildedRose {
                 	}
                     item.sellIn--;
                     break;
-                case "Sulfuras, Hand of Ragnaros":
+                case Constants.SULFURAS:
                 	//nothing changes for Sulfuras
                     break;
-                case "Conjured":
+                case Constants.CONJURED:
                 	//these degrade in quality twice as fast as normal items
                 	if (item.sellIn > 0) {
                 		//quality decreases with age, twice as fast

--- a/Java/src/test/java/com/gildedrose/GildedRoseTest.java
+++ b/Java/src/test/java/com/gildedrose/GildedRoseTest.java
@@ -8,7 +8,7 @@ class GildedRoseTest {
 
     @Test
     void brieQualityUpdate() {
-        Item[] items1 = new Item[] { new Item(Constants.BRIE.getName(), 1, 0) };
+        Item[] items1 = new Item[] { new Item(Constants.BRIE, 1, 0) };
         GildedRose app = new GildedRose(items1);
         
         //test quality update within range
@@ -41,7 +41,7 @@ class GildedRoseTest {
     @Test
     void passesQualityUpdate() {
         //Item - name, sellIn, quality
-        Item[] items1 = new Item[] { new Item(Constants.PASS.getName(), 9, 0) };
+        Item[] items1 = new Item[] { new Item(Constants.PASS, 9, 0) };
         GildedRose app = new GildedRose(items1);
         
         //test quality update within 10 days
@@ -69,7 +69,7 @@ class GildedRoseTest {
     //@Test
     void sulfurasNoOpUpdate() {
         //Item - name, sellIn, quality
-        Item[] items1 = new Item[] { new Item(Constants.SULFURAS.getName(), 100, 1000) };
+        Item[] items1 = new Item[] { new Item(Constants.SULFURAS, 100, 1000) };
         GildedRose app = new GildedRose(items1);
         
         //test quality updat
@@ -105,7 +105,7 @@ class GildedRoseTest {
     @Test
     void conjuredQualityUpdate() {
     	//Item - name, sellIn, quality
-        Item[] items1 = new Item[] { new Item(Constants.CONJURED.getName(), 10, 20) };
+        Item[] items1 = new Item[] { new Item(Constants.CONJURED, 10, 20) };
         GildedRose app = new GildedRose(items1);
         
         //test quality update within sellIn


### PR DESCRIPTION
Because we need to be able to create items with arbitrary names, enums are not the right fit. We are now using final Strings - this way, we are still using the same String, defined once, everywhere and we also retain the flexibility of creating items with any name.